### PR TITLE
Add parens to ternary expression

### DIFF
--- a/join-badguys.zed
+++ b/join-badguys.zed
@@ -3,4 +3,4 @@ from (
   BadGuys@main => sort addr ;
 )
 | inner join on id.resp_h=addr badguy:=true
-| _path:=has(_path) ? "badguy:"+_path : "badguy"
+| _path := (has(_path) ? "badguy:"+_path : "badguy")


### PR DESCRIPTION
A community user went through this README and got slightly confused by the usage of the ternary operator in the `join` example. In this user's own words:

> Just for some clarification on the badguy part of the presentation.  In the `join-badguys.zed` script, I understand the join part and I know it's use ternary operator that I read like
> 
> `condition ? exprIfTrue : exprIfFalse`
> 
> but should I read zed script more like `_path:= (has(_path) ? "badguy:"+_path : "badguy")` , which to me would put the `_path` equal to the result of the operation.  Otherwise when I first looked at it I thought the result of `has(_path)` would be put into `_path` and then the ternary operator.  Hopefully that makes sense?  I guess if I was writing it I would have expected `has(_path) ? _`_`path:="badguy:"+_`_`path : _path:="badguy"`

We talked a bit more about this and they agreed that wrapping the example in parens like they did above would have made it less confusing on first read. Since ternary operators might be less familiar to some users, I'm on board with the suggestion.